### PR TITLE
IMAGE_FS: add wic by default

### DIFF
--- a/conf/local.conf.append
+++ b/conf/local.conf.append
@@ -2,3 +2,5 @@ hostname_pn-base-files = "smes"
 
 IMAGE_INSTALL_append = " packagegroup-iot-ids-imx8mm "
 PACKAGECONFIG_append_pn-perf = " coresight"
+
+IMAGE_FSTYPES += " wic "


### PR DESCRIPTION
image only comes as .tar.bz2 which is annoying
to transfer and unzip everytime. Therefore, just
output a wic right away for a more enjoyable
development experience.

Signed-off-by: mitchdz <mitch_dz@hotmail.com>